### PR TITLE
Replace minified version with non minified one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Robert Weber <closingtag@gmail.com>"
   ],
   "description": "A Polyfill for CSS3 calc()",
-  "main": "calc.min.js",
+  "main": "calc.js",
   "keywords": [
     "css3",
     "calc",


### PR DESCRIPTION
When you use wiredep to automatically inject bower components into your app and have a concat and uglify process eg via grunt the non minified version is better practice. So you can debug with the unminified source and when building the app everything is getting concatenated and minified.