### PR TITLE
Sections of minified CSS ignored due to over-eager matching in KEYFRAMES regexp

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -37,7 +37,7 @@ fillcalc v0.1.0 - (c) Robert Weber, freely distributable under the terms of the 
 	CALC_RULE = '^(\\s*?[\\s\\S]*):(\\s*?[\\s\\S]*?((\\-(webkit|moz)\\-)?calc\\(([\\s\\S]+)\\))[\\s\\S]*)?$',
 	CSSRULES = '((\\s*?@media[\\s\\S]*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})',
 
-	KEYFRAMES = new RegExp('((@.*?keyframes [\\s\\S]*?){([\\s\\S]*?}\\s*?)})', 'gi'),
+	KEYFRAMES = new RegExp('((@[^{]*?keyframes [\\s\\S]*?){([\\s\\S]*?}\\s*?)})', 'gi'),
 	FONTFACE = new RegExp('((@font-face\\s*?){([\\s\\S]*?)})', 'gi'),
 	COMMENTS = new RegExp('(\\/\\*[\\s\\S]*?\\*\\/)', 'gi'),
 	IMPORTS = new RegExp('@import .*?;', 'gi'),


### PR DESCRIPTION
I found that the polyfill stopped working when it was operating on minified css.

I tracked the problem down to line 287 where the comments, imports, keyframes etc are stripped from the input css, and the problem was that the regex for keyframes matched entire chunks of css between the `@` and the word `keyframes`. An example string that it matched in my project was:

```css
@font-face{font-family:FontAwesome;/*... (many, many other rules here) ...*/}@-webkit-keyframes fa-spin{0%{-webkit-transform:rotate(0);/* ... */}}
```

I fixed it by excluding the `{` character from the characters that may appear between `@` and `keyframes`.